### PR TITLE
add hidden sheet title to mobile nav

### DIFF
--- a/src/components/ui/mobile-nav.tsx
+++ b/src/components/ui/mobile-nav.tsx
@@ -3,7 +3,12 @@
 import * as React from "react";
 import { Menu, ChevronDown, ChevronRight } from "lucide-react";
 import { Button } from "~/components/ui/button";
-import { Sheet, SheetContent, SheetTrigger } from "~/components/ui/sheet";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from "~/components/ui/sheet";
 import {
   Collapsible,
   CollapsibleContent,
@@ -83,6 +88,7 @@ export default function HamburgerMenu({
         </Button>
       </SheetTrigger>
       <SheetContent side="left" className="w-[240px] sm:w-[300px]">
+        <SheetTitle className="sr-only">Navigation</SheetTitle>
         <nav className="flex flex-col space-y-4">
           {menuItems.map((item) => (
             <MenuItemComponent key={item.title} item={item} />


### PR DESCRIPTION
## Summary
- Adds a visually hidden `SheetTitle` to the mobile navigation sheet.
- Improves accessibility by giving the dialog a programmatic title for assistive technologies.

## Testing
- Not run (UI-only change).
- Verified the mobile nav sheet now includes a `SheetTitle` with `sr-only` styling.